### PR TITLE
feat: add GitHub Actions deploy pipeline for Cloudflare Worker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+name: Deploy to Cloudflare Workers
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run build:worker
+
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy.yml` — triggers on push to `main`
- Builds `dist/mcp-worker.js` via `npm run build:worker` then deploys with `wrangler-action`
- `CLOUDFLARE_API_TOKEN` secret already set in repo settings

## Test plan
- [ ] Merge and confirm Actions tab shows a running deploy job
- [ ] Verify worker responds at `https://sn-docs-mcp.wiz0floyd.workers.dev/mcp` after deploy completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)