### PR TITLE
chore: opt into Node 24 for GitHub Actions runners

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var to the deploy workflow
- Opts in ahead of GitHub's forced migration on June 2, 2026

## Test plan
- [ ] Deploy run completes without Node 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)