### PR TITLE
feat: add version filter to search_docs

### DIFF
--- a/src/docs-client.ts
+++ b/src/docs-client.ts
@@ -45,11 +45,30 @@ export async function search(
   });
 
   const lang = options.lang ?? 'en-US';
-  // en-US articles have no lang segment in the URL path; other locales appear as /docs/r/<LANG>/
+  const version = options.version ?? 'current';
+
+  // Lang filter: en-US URLs have no lang segment; others have /r/xx-XX/
   const isRequestedLang = (url: string) =>
     lang === 'en-US'
       ? !/\/docs\/r\/[a-z]{2}-[A-Z]{2}\//.test(url)
       : url.includes(`/docs/r/${lang}/`);
+
+  // Version filter: ServiceNow release names are alphabetical city names.
+  // Versioned URLs: /docs/r/<release>/<product>/... e.g. /docs/r/zurich/itsm/...
+  // Current URLs:   /docs/r/<product>/...           e.g. /docs/r/itsm/...
+  const KNOWN_RELEASES = new Set([
+    'fuji', 'geneva', 'helsinki', 'istanbul', 'jakarta', 'kingston', 'london',
+    'madrid', 'newyork', 'orlando', 'paris', 'quebec', 'rome', 'sandiego',
+    'tokyo', 'utah', 'vancouver', 'washingtondc', 'xanadu', 'yokohama', 'zurich',
+    'australia', 'brazil',
+  ]);
+  const RELEASE_RE = /\/docs\/r\/([a-z]+)\//;
+  const getUrlVersion = (url: string): string => {
+    const m = url.match(RELEASE_RE);
+    return (m && KNOWN_RELEASES.has(m[1])) ? m[1] : 'current';
+  };
+  const isRequestedVersion = (url: string) =>
+    version === 'any' || getUrlVersion(url) === version;
 
   const seen = new Set<string>();
   const items: SearchResultItem[] = [];
@@ -58,6 +77,7 @@ export async function search(
       if (entry.type !== 'TOPIC') continue;
       const t = entry.topic;
       if (!isRequestedLang(t.readerUrl)) continue;
+      if (!isRequestedVersion(t.readerUrl)) continue;
       if (seen.has(t.contentUrl)) continue;
       seen.add(t.contentUrl);
       const excerpt = t.htmlExcerpt.replace(/<[^>]+>/g, '');

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -23,6 +23,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         properties: {
           query: { type: 'string', description: 'Search terms' },
           lang: { type: 'string', description: 'Language code, e.g. en-US (default), fr-FR, de-DE, ja-JP, ko-KR, pt-BR' },
+          version: { type: 'string', description: 'Release version: "current" (default, latest docs), a release name e.g. "zurich", "yokohama", "xanadu", or "any" (all versions)' },
           limit: { type: 'number', description: 'Results per page (default 10, max 50)' },
           page: { type: 'number', description: 'Page number, 1-based (default 1)' },
         },
@@ -65,12 +66,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   try {
     switch (name) {
       case 'search_docs': {
-        const { query, lang, limit, page } = args as {
-          query: string; lang?: string; limit?: number; page?: number;
+        const { query, lang, version, limit, page } = args as {
+          query: string; lang?: string; version?: string; limit?: number; page?: number;
         };
         const maxResults = Math.min(limit ?? 10, 50);
         const from = ((page ?? 1) - 1) * maxResults;
-        const { items, paging } = await search({ query, lang, maxResults, from });
+        const { items, paging } = await search({ query, lang, version, maxResults, from });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify({ items, paging }, null, 2) }],
         };

--- a/src/mcp-worker.ts
+++ b/src/mcp-worker.ts
@@ -27,6 +27,7 @@ function buildServer(): Server {
           properties: {
             query: { type: 'string', description: 'Search terms' },
             lang: { type: 'string', description: 'Language code, e.g. en-US (default), fr-FR, de-DE, ja-JP, ko-KR, pt-BR' },
+            version: { type: 'string', description: 'Release version: "current" (default, latest docs), a release name e.g. "zurich", "yokohama", "xanadu", or "any" (all versions)' },
             limit: { type: 'number', description: 'Results per page (default 10, max 50)' },
             page: { type: 'number', description: 'Page number, 1-based (default 1)' },
           },
@@ -69,12 +70,12 @@ function buildServer(): Server {
     try {
       switch (name) {
         case 'search_docs': {
-          const { query, lang, limit, page } = args as {
-            query: string; lang?: string; limit?: number; page?: number;
+          const { query, lang, version, limit, page } = args as {
+            query: string; lang?: string; version?: string; limit?: number; page?: number;
           };
           const maxResults = Math.min(limit ?? 10, 50);
           const from = ((page ?? 1) - 1) * maxResults;
-          const { items, paging } = await search({ query, lang, maxResults, from });
+          const { items, paging } = await search({ query, lang, version, maxResults, from });
           return {
             content: [{ type: 'text' as const, text: JSON.stringify({ items, paging }, null, 2) }],
           };

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@
 export interface SearchOptions {
   query: string;
   lang?: string;
+  version?: string;  // "current" (default), "any", or a release name e.g. "zurich"
   maxResults?: number;
   from?: number;
 }


### PR DESCRIPTION
## Summary
- Adds optional `version` param to `search_docs`: `"current"` (default), a release name e.g. `"zurich"`, `"washingtondc"`, or `"any"` for all versions
- Defaults to current docs — eliminates cross-version duplicates without user action
- Uses an allowlist of known ServiceNow release names to distinguish release segments from product-area path segments
- Also fixes `washington` → `washingtondc` (actual URL segment) and adds `australia`, `brazil`

## Test plan
- [ ] Default search returns only current-version results (no zurich/yokohama/etc URLs)
- [ ] `version="zurich"` returns only Zurich-versioned results
- [ ] `version="any"` returns mixed versions
- [ ] 32/32 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)