### PR TITLE
chore: release v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sn-docs",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sn-docs",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "commander": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sn-docs",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "CLI and MCP server for querying docs.servicenow.com",
   "type": "module",
   "engines": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,22 +6,24 @@ import { DocsApiError } from './types.js';
 const program = new Command()
   .name('sn-docs')
   .description('Query ServiceNow documentation')
-  .version('0.1.0');
+  .version('1.0.0');
 
 program
   .command('search <query>')
   .description('Search ServiceNow docs')
   .option('-l, --lang <lang>', 'Language code', 'en-US')
+  .option('-v, --release-version <version>', 'Release version: "current" (default), a release name e.g. "zurich", or "any"', 'current')
   .option('-n, --limit <n>', 'Results per page', '10')
   .option('-p, --page <n>', 'Page number (1-based)', '1')
   .option('--json', 'Output raw JSON')
-  .action(async (query: string, opts: { lang: string; limit: string; page: string; json?: boolean }) => {
+  .action(async (query: string, opts: { lang: string; releaseVersion: string; limit: string; page: string; json?: boolean }) => {
     try {
       const limit = parseInt(opts.limit, 10);
       const page = parseInt(opts.page, 10);
       const { items, paging } = await search({
         query,
         lang: opts.lang,
+        version: opts.releaseVersion,
         maxResults: limit,
         from: (page - 1) * limit,
       });

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -9,7 +9,7 @@ import { toMarkdown } from './formatter.js';
 import { DocsApiError } from './types.js';
 
 const server = new Server(
-  { name: 'sn-docs', version: '0.1.0' },
+  { name: 'sn-docs', version: '1.0.0' },
   { capabilities: { tools: {} } },
 );
 

--- a/src/mcp-worker.ts
+++ b/src/mcp-worker.ts
@@ -13,7 +13,7 @@ interface Env {
 
 function buildServer(): Server {
   const server = new Server(
-    { name: 'sn-docs', version: '0.1.0' },
+    { name: 'sn-docs', version: '1.0.0' },
     { capabilities: { tools: {} } },
   );
 


### PR DESCRIPTION
## Summary
- Bumps all version strings to `1.0.0` (package.json, CLI, both MCP servers)
- Adds `-v / --release-version <version>` flag to CLI `search` command — matches the MCP `version` param added in #6

## Test plan
- [ ] `sn-docs search "incident" --release-version zurich` returns only Zurich-versioned results
- [ ] `sn-docs --version` outputs `1.0.0`
- [ ] 32/32 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)