### PR TITLE
fix: fetch timeout, NaN validation, version from package.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,16 @@ npm test
 - Include a clear description of what changed and why
 - Link any related issues
 
+## Versioning
+
+Bump `package.json` version as part of every PR — it is the single source of truth (both `cli.ts` and `mcp-server.ts` read from it at runtime):
+
+| Change type | Bump |
+|---|---|
+| Bug fix | patch (`1.0.0` → `1.0.1`) |
+| New feature, backwards-compatible | minor (`1.0.0` → `1.1.0`) |
+| Breaking change | major (`1.0.0` → `2.0.0`) |
+
 ## API notes
 
 The Fluid Docs API base is `https://www.servicenow.com/docs/api/khub`. It is public and requires no authentication. The main endpoints are documented in `src/docs-client.ts`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sn-docs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "CLI and MCP server for querying docs.servicenow.com",
   "type": "module",
   "engines": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,12 +1,15 @@
+import { createRequire } from 'module';
 import { Command } from 'commander';
 import { search, suggest, getLocales, getContent } from './docs-client.js';
 import { toMarkdown } from './formatter.js';
 import { DocsApiError } from './types.js';
 
+const { version } = createRequire(import.meta.url)('../package.json') as { version: string };
+
 const program = new Command()
   .name('sn-docs')
   .description('Query ServiceNow documentation')
-  .version('1.0.0');
+  .version(version);
 
 program
   .command('search <query>')
@@ -20,6 +23,14 @@ program
     try {
       const limit = parseInt(opts.limit, 10);
       const page = parseInt(opts.page, 10);
+      if (isNaN(limit) || limit < 1) {
+        process.stderr.write('Error: --limit must be a positive integer\n');
+        process.exit(1);
+      }
+      if (isNaN(page) || page < 1) {
+        process.stderr.write('Error: --page must be a positive integer\n');
+        process.exit(1);
+      }
       const { items, paging } = await search({
         query,
         lang: opts.lang,

--- a/src/docs-client.ts
+++ b/src/docs-client.ts
@@ -5,14 +5,26 @@ import type {
 import { DocsApiError } from './types.js';
 
 const BASE = 'https://www.servicenow.com/docs/api/khub';
+const TIMEOUT_MS = 10_000;
 
 async function fetchWithRetry(url: string, init?: RequestInit): Promise<Response> {
   let lastRes: Response | undefined;
   for (let attempt = 0; attempt < 2; attempt++) {
     if (attempt > 0) await new Promise<void>(r => setTimeout(r, 500));
-    const res = await fetch(url, init);
-    if (res.ok || res.status < 500) return res;
-    lastRes = res;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+    try {
+      const res = await fetch(url, { ...init, signal: controller.signal });
+      if (res.ok || res.status < 500) return res;
+      lastRes = res;
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new DocsApiError(408, `Request timed out after ${TIMEOUT_MS / 1000}s`);
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
   }
   return lastRes!;
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'module';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
@@ -8,8 +9,10 @@ import { search, suggest, getLocales, getContent } from './docs-client.js';
 import { toMarkdown } from './formatter.js';
 import { DocsApiError } from './types.js';
 
+const { version } = createRequire(import.meta.url)('../package.json') as { version: string };
+
 const server = new Server(
-  { name: 'sn-docs', version: '1.0.0' },
+  { name: 'sn-docs', version },
   { capabilities: { tools: {} } },
 );
 


### PR DESCRIPTION
## Summary
- **#10** — `fetchWithRetry` now uses `AbortController` with a 10s timeout; throws `DocsApiError(408)` on abort rather than hanging indefinitely
- **#11** — `--limit` and `--page` are validated as positive integers immediately after `parseInt`; exits with a clear error message instead of silently passing `NaN` to the API
- **#16** — `cli.ts` and `mcp-server.ts` read `version` from `package.json` at runtime via `createRequire`; no more hardcoded strings to drift
- `CONTRIBUTING.md` — documents the semver bump convention (patch/minor/major) so the version rule is part of the PR process going forward

Closes #10, #11, #16

## Test plan
- [ ] `npm run lint` passes (no TypeScript errors)
- [ ] `npm test` passes (32 tests)
- [ ] `sn-docs search "incident" --limit abc` prints `Error: --limit must be a positive integer` and exits 1
- [ ] `sn-docs --version` prints `1.0.1` (from package.json)
- [ ] Kill network mid-request — CLI exits within ~10s with timeout error rather than hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)