### PR TITLE
fix: validate lang against supported locales before search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sn-docs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sn-docs",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "commander": "^12.0.0",
@@ -17,6 +17,7 @@
         "sn-docs-mcp": "bin/sn-docs-mcp.js"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/node": "^20.0.0",
         "@types/turndown": "^5.0.5",
         "esbuild": "^0.28.0",
@@ -546,6 +547,22 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2244,6 +2261,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sn-docs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sn-docs",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "commander": "^12.0.0",
@@ -17,7 +17,6 @@
         "sn-docs-mcp": "bin/sn-docs-mcp.js"
       },
       "devDependencies": {
-        "@playwright/test": "^1.59.1",
         "@types/node": "^20.0.0",
         "@types/turndown": "^5.0.5",
         "esbuild": "^0.28.0",
@@ -547,22 +546,6 @@
         "zod": {
           "optional": false
         }
-      }
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright": "1.59.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2261,53 +2244,6 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.59.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/postcss": {
       "version": "8.5.10",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "turndown": "^7.2.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.59.1",
     "@types/node": "^20.0.0",
     "@types/turndown": "^5.0.5",
     "esbuild": "^0.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sn-docs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "CLI and MCP server for querying docs.servicenow.com",
   "type": "module",
   "engines": {
@@ -26,6 +26,7 @@
     "turndown": "^7.2.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/node": "^20.0.0",
     "@types/turndown": "^5.0.5",
     "esbuild": "^0.28.0",

--- a/src/docs-client.ts
+++ b/src/docs-client.ts
@@ -44,6 +44,7 @@ async function requestText(url: string, init?: RequestInit): Promise<string> {
 export async function search(
   options: SearchOptions,
 ): Promise<{ items: SearchResultItem[]; paging: SearchResponse['paging'] }> {
+  await assertLangSupported(options.lang ?? 'en-US');
   const body = {
     query: options.query,
     lang: options.lang ?? 'en-US',
@@ -111,9 +112,31 @@ export async function suggest(input: string): Promise<string[]> {
   return data.suggestions.map(s => s.value);
 }
 
+let _localesCache: ContentLocale[] | undefined;
+
 export async function getLocales(): Promise<ContentLocale[]> {
-  const data = await request<LocalesResponse>(`${BASE}/locales`);
-  return data.contentLocales;
+  if (!_localesCache) {
+    const data = await request<LocalesResponse>(`${BASE}/locales`);
+    _localesCache = data.contentLocales;
+  }
+  return _localesCache;
+}
+
+/** Exposed for unit tests only — clears the locales cache. */
+export function _resetLocalesCache(): void {
+  _localesCache = undefined;
+}
+
+async function assertLangSupported(lang: string): Promise<void> {
+  if (lang === 'en-US') return;
+  const locales = await getLocales();
+  const supported = locales.map(l => l.lang);
+  if (!supported.includes(lang)) {
+    throw new DocsApiError(
+      400,
+      `Locale '${lang}' is not available. Supported locales: ${supported.join(', ')}`,
+    );
+  }
 }
 
 export async function getContent(url: string): Promise<string> {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -25,7 +25,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         type: 'object' as const,
         properties: {
           query: { type: 'string', description: 'Search terms' },
-          lang: { type: 'string', description: 'Language code, e.g. en-US (default), fr-FR, de-DE, ja-JP, ko-KR, pt-BR' },
+          lang: { type: 'string', description: 'BCP-47 language code (default: en-US). Not all locales are available — use the list_locales tool to see valid values.' },
           version: { type: 'string', description: 'Release version: "current" (default, latest docs), a release name e.g. "zurich", "yokohama", "xanadu", or "any" (all versions)' },
           limit: { type: 'number', description: 'Results per page (default 10, max 50)' },
           page: { type: 'number', description: 'Page number, 1-based (default 1)' },

--- a/tests/docs-client.test.ts
+++ b/tests/docs-client.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { search, suggest, getLocales, getContent } from '../src/docs-client.js';
+import { search, suggest, getLocales, getContent, _resetLocalesCache } from '../src/docs-client.js';
 import { DocsApiError } from '../src/types.js';
 
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
-beforeEach(() => mockFetch.mockReset());
+beforeEach(() => {
+  mockFetch.mockReset();
+  _resetLocalesCache();
+});
 
 function ok(data: unknown) {
   return Promise.resolve({
@@ -70,10 +73,19 @@ describe('search()', () => {
   });
 
   it('passes through lang, maxResults, from options', async () => {
-    mockFetch.mockReturnValueOnce(ok({ ...SEARCH_RESPONSE, results: [] }));
-    await search({ query: 'flow', lang: 'fr-FR', maxResults: 5, from: 10 });
-    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(JSON.parse(init.body as string)).toEqual({ query: 'flow', lang: 'fr-FR', maxResults: 5, from: 10 });
+    mockFetch
+      .mockReturnValueOnce(ok({ contentLocales: [{ lang: 'en-US', label: 'English', count: 452 }, { lang: 'de-DE', label: 'Deutsch', count: 200 }] }))
+      .mockReturnValueOnce(ok({ ...SEARCH_RESPONSE, results: [] }));
+    await search({ query: 'flow', lang: 'de-DE', maxResults: 5, from: 10 });
+    const [, init] = mockFetch.mock.calls[1] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({ query: 'flow', lang: 'de-DE', maxResults: 5, from: 10 });
+  });
+
+  it('throws DocsApiError(400) for unsupported locale', async () => {
+    mockFetch.mockReturnValueOnce(ok({ contentLocales: [{ lang: 'en-US', label: 'English', count: 452 }] }));
+    await expect(search({ query: 'incident', lang: 'fr-FR' }))
+      .rejects.toMatchObject({ statusCode: 400, message: expect.stringContaining('fr-FR') });
+    expect(mockFetch).toHaveBeenCalledTimes(1); // locales only, no search call
   });
 
   it('retries once on 5xx then throws DocsApiError', async () => {

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -14,10 +14,9 @@ describe.skipIf(SKIP)('Integration: live API', () => {
     expect(items[0].contentUrl).toMatch(/\/api\/khub\/maps\//);
   });
 
-  it('search() with lang=fr-FR returns French results', async () => {
-    const { items } = await search({ query: 'incident', lang: 'fr-FR', maxResults: 3 });
-    expect(items.length).toBeGreaterThan(0);
-    expect(items.some(i => i.readerUrl.includes('fr-FR') || i.breadcrumb.length > 0)).toBe(true);
+  it('search() with lang=fr-FR throws DocsApiError (fr-FR not available)', async () => {
+    await expect(search({ query: 'incident', lang: 'fr-FR', maxResults: 3 }))
+      .rejects.toMatchObject({ statusCode: 400, message: expect.stringContaining('fr-FR') });
   });
 
   it('search() pagination works', async () => {


### PR DESCRIPTION
## Summary
- Requesting `lang: 'fr-FR'` (or any unsupported locale) silently returned zero results — the API returned a multi-locale dump and `isRequestedLang` correctly filtered everything out, leaving the caller with no results and no explanation
- Validated the issue with a Playwright API probe: the live API returns `de-DE`, `ja-JP`, `ko-KR`, `pt-BR`, and `en-US` results for a French search, but never any `fr-FR` URLs
- Added `assertLangSupported()` that fetches `/locales` once per process (cached), then throws `DocsApiError(400)` for unsupported locales with the full supported list in the message

## Test plan
- [ ] `npm test` — all 33 unit tests pass
- [ ] `npm run lint` — no TypeScript errors
- [ ] Integration: `npm run test:integration` — French test now expects a 400 error instead of results
- [ ] Manual: `node bin/sn-docs.js search "incident" --lang fr-FR` should print a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)