### PR TITLE
chore: package v1.1.0 with CLI, local MCP, and cloud MCP worker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm test
+
+      - run: npm run build:release
+
+      - name: Upload release artifacts
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} \
+            release/sn-docs-cli.mjs \
+            release/sn-docs-mcp.mjs \
+            release/sn-docs-mcp-worker.js
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sn-docs",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "CLI and MCP server for querying docs.servicenow.com",
   "type": "module",
   "engines": {
@@ -18,7 +18,7 @@
     "test": "vitest run",
     "test:integration": "INTEGRATION=true vitest run tests/integration.test.ts",
     "lint": "tsc --noEmit",
-    "build:release": "node -e \"require('fs').mkdirSync('release',{recursive:true})\" && npx esbuild src/cli.ts --bundle --platform=node --target=node20 --format=cjs --outfile=release/sn-docs-cli.cjs --banner:js=\"#!/usr/bin/env node\" && npx esbuild src/mcp-server.ts --bundle --platform=node --target=node20 --format=cjs --outfile=release/sn-docs-mcp.cjs --banner:js=\"#!/usr/bin/env node\""
+    "build:release": "node -e \"require('fs').mkdirSync('release',{recursive:true})\" && npx esbuild src/cli.ts --bundle --platform=node --target=node20 --format=esm --outfile=release/sn-docs-cli.mjs --banner:js=\"#!/usr/bin/env node\" && npx esbuild src/mcp-server.ts --bundle --platform=node --target=node20 --format=esm --outfile=release/sn-docs-mcp.mjs --banner:js=\"#!/usr/bin/env node\" && npx esbuild src/mcp-worker.ts --bundle --platform=browser --format=esm --target=esnext --outfile=release/sn-docs-mcp-worker.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -14,9 +14,18 @@ describe.skipIf(SKIP)('Integration: live API', () => {
     expect(items[0].contentUrl).toMatch(/\/api\/khub\/maps\//);
   });
 
-  it('search() with lang=fr-FR throws DocsApiError (fr-FR not available)', async () => {
-    await expect(search({ query: 'incident', lang: 'fr-FR', maxResults: 3 }))
-      .rejects.toMatchObject({ statusCode: 400, message: expect.stringContaining('fr-FR') });
+  it('search() with unsupported lang throws DocsApiError', async () => {
+    await expect(search({ query: 'incident', lang: 'xx-XX', maxResults: 3 }))
+      .rejects.toMatchObject({ statusCode: 400, message: expect.stringContaining('xx-XX') });
+  });
+
+  it('search() with lang=fr-FR and version=any returns results', async () => {
+    // The current release (Australia) is pre-GA and lacks translated docs, so
+    // non-English results only exist under versioned URLs (e.g. /docs/r/fr-FR/zurich/).
+    // Use version="any" until Australia ships with translations.
+    const { items } = await search({ query: 'gestion des incidents', lang: 'fr-FR', version: 'any', maxResults: 3 });
+    expect(items.length).toBeGreaterThan(0);
+    expect(items[0].readerUrl).toContain('/fr-FR/');
   });
 
   it('search() pagination works', async () => {


### PR DESCRIPTION
## Summary
- Extends `build:release` to produce all three artifacts: `sn-docs-cli.mjs`, `sn-docs-mcp.mjs`, `sn-docs-mcp-worker.js`
- Switches CLI and local MCP builds from CJS to ESM (`.mjs`) to match the project's `"type": "module"` setting
- Creates `release.yml` workflow that uploads all three files on GitHub release publish
- Bumps version to 1.1.0 (minor — new cloud MCP artifact in release)
- Fixes fr-FR integration test: use `xx-XX` for unsupported locale check; add `version=any` test for translated content that exists under versioned URLs

## Test plan
- [ ] `npm run build:release` produces `release/sn-docs-cli.mjs`, `release/sn-docs-mcp.mjs`, `release/sn-docs-mcp-worker.js`
- [ ] `npm test` passes (50 tests)
- [ ] After merge, publish a GitHub release tagged `v1.1.0` and confirm the Actions workflow uploads all three artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)