### PR TITLE
fix: add contents: write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ env:
 jobs:
   build-and-upload:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN` requires an explicit `contents: write` permission to upload assets to a GitHub release; the default read-only token caused a 403 on `gh release upload`

## Test plan
- [ ] Merge and re-run the release workflow against `v1.1.0` — artifacts should upload successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)