### PR TITLE
ci: add lint and test quality gate to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,14 @@ jobs:
 
       - run: npm ci
 
-      - run: npm run build:worker
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Build worker
+        run: npm run build:worker
 
       - uses: cloudflare/wrangler-action@v3
         with:


### PR DESCRIPTION
## Summary
- Adds `npm run lint` and `npm test` steps before `npm run build:worker` in the deploy workflow
- Ensures TypeScript errors and failing tests block deployment before a broken commit can reach production

Closes #13

## Test plan
- [ ] Push a commit with a TypeScript error to a branch and confirm the lint step fails and deployment is blocked
- [ ] Push a commit with a failing test and confirm the test step fails and deployment is blocked
- [ ] Push a valid commit and confirm all steps pass and deployment proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)