### PR TITLE
fix: clean dist/ before tsc to remove orphaned artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "sn-docs-mcp": "bin/sn-docs-mcp.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "node -e \"require('fs').rmSync('dist', {recursive:true,force:true})\" && tsc",
     "build:worker": "esbuild src/mcp-worker.ts --bundle --platform=browser --format=esm --target=esnext --outfile=dist/mcp-worker.js",
     "dev:cli": "tsx src/cli.ts",
     "dev:mcp": "tsx src/mcp-server.ts",


### PR DESCRIPTION
## Summary
- Adds a `dist/` clean step before `tsc` in the `build` script so renamed or deleted source files don't leave stale `.js`/`.d.ts` artifacts that could be accidentally imported or shipped
- Uses inline `node -e` (consistent with `build:release`) — no new dependency added

Closes #17

## Test plan
- [x] `npm run build` completes without error
- [ ] Rename or delete a source file, run `npm run build`, verify the old output is gone from `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)